### PR TITLE
Themed/monochrome icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
https://github.com/hardcore-sushi/DroidFS/issues/176 led to a misunderstanding. He probably means themed icons, a new Android 13 feature which uses the wallpaper colors for the app icon. See [user theming](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive). I believe this PR will fix the issue.

I provided some screenshots for you to see the difference.
![Screenshot_20230422-231900_Trebuchet](https://user-images.githubusercontent.com/115667885/233807458-103e1091-fec6-4595-a5af-7c904b2b5177.png)
![Screenshot_20230422-231733_Trebuchet](https://user-images.githubusercontent.com/115667885/233807464-b11b129c-c6dc-468a-be1a-a61b825a736a.png)
