### PR TITLE
Remember app used to open file format

### DIFF
--- a/app/src/main/java/sushi/hardcore/droidfs/FileShare.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/FileShare.kt
@@ -66,12 +66,16 @@ class FileShare(context: Context) {
         return if (result == null) {
             Pair(null, R.string.export_failed_export)
         } else {
+            val appName = TemporaryFileProvider.instance.getAppPreference(File(exportedFile.path).extension)
             Pair(Intent(Intent.ACTION_VIEW).apply {
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 if (usfSafWrite) {
                     addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                 }
                 setDataAndType(result.first, result.second)
+                if (appName != null) {
+                    setPackage(appName)
+                }
             }, null)
         }
     }

--- a/app/src/main/java/sushi/hardcore/droidfs/adapters/OpenAsDialogAdapter.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/adapters/OpenAsDialogAdapter.kt
@@ -3,7 +3,7 @@ package sushi.hardcore.droidfs.adapters
 import android.content.Context
 import sushi.hardcore.droidfs.R
 
-class OpenAsDialogAdapter(context: Context, showOpenWithExternalApp: Boolean) : IconTextDialogAdapter(context) {
+class OpenAsDialogAdapter(context: Context, showOpenWithExternalApp: Boolean, preferredApp: String?) : IconTextDialogAdapter(context) {
     private val openAsItems: MutableList<List<Any>> = mutableListOf(
         listOf("image", R.string.image, R.drawable.icon_file_image),
         listOf("video", R.string.video, R.drawable.icon_file_video),
@@ -16,5 +16,11 @@ class OpenAsDialogAdapter(context: Context, showOpenWithExternalApp: Boolean) : 
             openAsItems.add(listOf("external", R.string.external_open, R.drawable.icon_open_in_new))
         }
         items = openAsItems
+        if (preferredApp != null) {
+            val preferredAppIndex = openAsItems.indexOfFirst { it[0] == preferredApp }
+            if (preferredAppIndex != -1) {
+                items = listOf(openAsItems[preferredAppIndex]) + openAsItems.filterIndexed { index, _ -> index != preferredAppIndex }
+            }
+        }
     }
 }

--- a/app/src/main/java/sushi/hardcore/droidfs/content_providers/TemporaryFileProvider.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/content_providers/TemporaryFileProvider.kt
@@ -43,6 +43,7 @@ class TemporaryFileProvider : ContentProvider() {
     private lateinit var volumeManager: VolumeManager
     lateinit var encryptedFileProvider: EncryptedFileProvider
     private val files = HashMap<Uri, ProvidedFile>()
+    private val appPreferences = mutableMapOf<String, String>()
 
     override fun onCreate(): Boolean {
         return context?.let {
@@ -71,6 +72,14 @@ class TemporaryFileProvider : ContentProvider() {
         return Uri.withAppendedPath(BASE_URI, UUID.randomUUID().toString()).also {
             files[it] = ProvidedFile(exportedFile, size, volumeId)
         }
+    }
+
+    fun storeAppPreference(fileType: String, appName: String) {
+        appPreferences[fileType] = appName
+    }
+
+    fun getAppPreference(fileType: String): String? {
+        return appPreferences[fileType]
     }
 
     override fun query(

--- a/app/src/main/java/sushi/hardcore/droidfs/explorers/BaseExplorerActivity.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/explorers/BaseExplorerActivity.kt
@@ -315,7 +315,14 @@ open class BaseExplorerActivity : BaseActivity(), ExplorerElementAdapter.Listene
                 FileTypes.isAudio(fullPath) -> {
                     startFileViewer(AudioPlayer::class.java, fullPath)
                 }
-                else -> showOpenAsDialog(explorerElements[position])
+                else -> {
+                    val preferredApp = getPreferredAppForFileType(fullPath)
+                    if (preferredApp != null) {
+                        openWithExternalApp(fullPath, explorerElements[position].stat.size)
+                    } else {
+                        showOpenAsDialog(explorerElements[position])
+                    }
+                }
             }
         }
         invalidateOptionsMenu()
@@ -675,5 +682,15 @@ open class BaseExplorerActivity : BaseActivity(), ExplorerElementAdapter.Listene
             TemporaryFileProvider.instance.wipe()
         }
         setCurrentPath(currentDirectoryPath)
+    }
+
+    private fun storePreferredAppForFileType(fileType: String, appName: String) {
+        val editor = sharedPrefs.edit()
+        editor.putString("preferred_app_$fileType", appName)
+        editor.apply()
+    }
+
+    private fun getPreferredAppForFileType(fileType: String): String? {
+        return sharedPrefs.getString("preferred_app_$fileType", null)
     }
 }


### PR DESCRIPTION
Add functionality to remember and use preferred app for opening file formats.

* **BaseExplorerActivity.kt**
  - Add methods to store and retrieve preferred app for file types.
  - Modify `onExplorerElementClick` to use stored app preference if available.

* **OpenAsDialogAdapter.kt**
  - Modify constructor to accept preferred app.
  - Adjust items to prioritize preferred app if available.

* **TemporaryFileProvider.kt**
  - Add methods to store and retrieve app preferences.

* **FileShare.kt**
  - Retrieve and set preferred app when sharing files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hardcore-sushi/DroidFS/pull/326?shareId=24666f5d-c63c-400e-b94d-6bec3a5db792).