### PR TITLE
Show password toggle in volume opener

### DIFF
--- a/app/src/main/res/layout/dialog_open_volume.xml
+++ b/app/src/main/res/layout/dialog_open_volume.xml
@@ -1,21 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:paddingHorizontal="@dimen/dialog_horizontal_padding">
 
-    <EditText
-        android:id="@+id/edit_password"
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:inputType="textPassword"
-        android:maxLines="1"
-        android:autofillHints="password"
-        android:hint="@string/password"
-        android:imeOptions="actionDone">
-        <requestFocus/>
-    </EditText>
+        app:hintEnabled="false"
+        app:endIconMode="password_toggle">
+
+        <EditText
+            android:id="@+id/edit_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword"
+            android:maxLines="1"
+            android:autofillHints="password"
+            android:hint="@string/password"
+            android:imeOptions="actionDone">
+            <requestFocus/>
+        </EditText>
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <CheckBox
         android:id="@+id/checkbox_default_open"


### PR DESCRIPTION
This resolves #249 

Adds an eye button to toggle password visibility in the volume opener dialog.

Note: Did not add it to other places where password is entered (e.g. creating volume, changing password), only the volume opener for now.

<img src="https://github.com/user-attachments/assets/1e656167-bcc2-40a7-931e-62c650e2df3b" width=200> <img src="https://github.com/user-attachments/assets/c3c884b3-962f-40f5-bead-71c5badab87b" width=200>
