### PR TITLE
Fix keyboard covering TextEditor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,7 +54,7 @@
         <activity android:name=".file_viewers.VideoPlayer" android:configChanges="screenSize|orientation" />
         <activity android:name=".file_viewers.PdfViewer" android:configChanges="screenSize|orientation" android:theme="@style/AppTheme" />
         <activity android:name=".file_viewers.AudioPlayer" android:configChanges="screenSize|orientation" />
-        <activity android:name=".file_viewers.TextEditor" android:configChanges="screenSize|orientation" />
+        <activity android:name=".file_viewers.TextEditor" android:configChanges="screenSize|orientation" android:windowSoftInputMode="adjustResize" />
         <activity android:name=".CameraActivity" android:screenOrientation="nosensor" />
         <activity android:name=".LogcatActivity"/>
 


### PR DESCRIPTION
This fixes #374.

Allows TextEditor Activity to vertically shrink to fit keyboard when software keyboard is open.