### PR TITLE
Apply 3x zoom limit only to double-tap zoom

### DIFF
--- a/app/src/main/java/sushi/hardcore/droidfs/widgets/ZoomableImageView.java
+++ b/app/src/main/java/sushi/hardcore/droidfs/widgets/ZoomableImageView.java
@@ -218,10 +218,7 @@ public class ZoomableImageView extends androidx.appcompat.widget.AppCompatImageV
             float mScaleFactor = detector.getScaleFactor();
             float origScale = saveScale;
             saveScale *= mScaleFactor;
-            if (saveScale > maxScale) {
-                saveScale = maxScale;
-                mScaleFactor = maxScale / origScale;
-            } else if (saveScale < minScale) {
+            if (saveScale < minScale) {
                 saveScale = minScale;
                 mScaleFactor = minScale / origScale;
             }


### PR DESCRIPTION
As per https://github.com/hardcore-sushi/DroidFS/issues/275#issuecomment-1986507212, the maximum zoom limit for images should only apply to double-tap zoom, not for manual pinch zoom. This pull request makes the change accordingly.

I have not introduced a facility to customise the maximum zoom level for manual pinch zoom, as I do not see that being a useful feature.