### PR TITLE
Fix isChildOf prefix match to require a path separator boundary

### DIFF
--- a/app/src/main/java/sushi/hardcore/droidfs/util/PathUtils.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/util/PathUtils.kt
@@ -59,10 +59,16 @@ object PathUtils {
     }
 
     fun isChildOf(childPath: String, parentPath: String): Boolean {
-        if (parentPath.length > childPath.length){
+        if (parentPath.length >= childPath.length) {
             return false
         }
-        return childPath.substring(0, parentPath.length) == parentPath
+        if (childPath.substring(0, parentPath.length) != parentPath) {
+            return false
+        }
+        // Require a separator boundary: the prefix must end with '/' or the first
+        // char of the child after the prefix must be '/'. Prevents "/foobar" from
+        // being treated as a child of "/foo".
+        return parentPath.endsWith(SEPARATOR) || childPath[parentPath.length] == SEPARATOR
     }
 
     fun getFilenameFromURI(context: Context, uri: Uri): String? {


### PR DESCRIPTION
## Summary
Fixes a path-prefix confusion in `PathUtils.isChildOf`.

`isChildOf` determined the parent/child relationship with a bare
string-prefix comparison, without requiring a separator boundary:

    isChildOf("/foobar", "/foo")  // returned true

The value feeds `VolumeProvider.isChildDocument`
(`VolumeProvider.kt:119`), which the Storage Access Framework calls to
verify that a `documentId` belongs to a granted tree. With the unsafe
`usf_expose` feature enabled and a SAF grant on a non-root subfolder,
an app could craft sibling documentIds (e.g. `/foobar`, `/foo.txt`)
and have them accepted as in-tree, reaching files never granted.

## Fix
Require a separator boundary: a path is a child only when it equals
the parent plus a `/`-delimited segment. Root (`/`) and trailing-slash
parents are handled, and equal paths are no longer treated as a child
of themselves.

## Impact on existing callers
The only other caller, the copy/move loop in `BaseExplorerActivity`,
operates on genuine descendants and is unaffected; removing the
self-as-child case avoids a redundant remap.

## Testing
Verified the new logic against 12 edge cases with the Kotlin compiler
(original bug, genuine children, root parent, equal paths, trailing
slash). DroidFS has no automated test suite and a full Android build
(SDK + NDK r25c) was not run; the change is pure string-comparison
logic with no native dependencies.
