### PR TITLE
Add .mts, .m2ts and .avi video format support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,10 +130,12 @@ dependencies {
 
     implementation "androidx.biometric:biometric-ktx:1.2.0-alpha05"
 
-    def media3_version = "1.3.1"
+    def media3_version = "1.7.1"
     implementation "androidx.media3:media3-exoplayer:$media3_version"
+    implementation "org.jellyfin.media3:media3-ffmpeg-decoder:1.6.1+2" // Built against Media3 1.7.1
     implementation "androidx.media3:media3-ui:$media3_version"
     implementation "androidx.media3:media3-datasource:$media3_version"
+    implementation "com.github.dburckh:Media3Avi:2.7.1"
 
     def camerax_version = "1.3.4"
     implementation "androidx.camera:camera-camera2:$camerax_version"

--- a/app/src/main/java/sushi/hardcore/droidfs/FileTypes.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/FileTypes.kt
@@ -5,7 +5,7 @@ import java.io.File
 object FileTypes {
     private val FILE_EXTENSIONS = mapOf(
         Pair("image", listOf("png", "jpg", "jpeg", "gif", "avif", "webp", "bmp", "heic")),
-        Pair("video", listOf("mp4", "webm", "mkv", "mov", "m4v")),
+        Pair("video", listOf("mp4", "webm", "mkv", "mov", "m4v", "mts", "m2ts", "avi")),
         Pair("audio", listOf("mp3", "ogg", "m4a", "wav", "flac", "opus")),
         Pair("pdf", listOf("pdf")),
         Pair("text", listOf(

--- a/app/src/main/java/sushi/hardcore/droidfs/file_viewers/EncryptedVolumeDataSource.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/file_viewers/EncryptedVolumeDataSource.kt
@@ -9,6 +9,7 @@ import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.TransferListener
 import sushi.hardcore.droidfs.Constants
 import sushi.hardcore.droidfs.filesystems.EncryptedVolume
+import java.io.IOException
 import kotlin.math.min
 
 @OptIn(UnstableApi::class)
@@ -19,13 +20,21 @@ class EncryptedVolumeDataSource(private val encryptedVolume: EncryptedVolume, pr
     private var bytesRemaining: Long = -1
 
     override fun open(dataSpec: DataSpec): Long {
+        close()
         fileHandle = encryptedVolume.openFileReadMode(filePath)
+        if (fileHandle == -1L) {
+            throw IOException("Failed to open encrypted media")
+        }
         fileOffset = dataSpec.position
-        val fileSize = encryptedVolume.getAttr(filePath)!!.size
+        val fileSize = encryptedVolume.getAttr(filePath)?.size ?: run {
+            close()
+            throw IOException("Failed to read encrypted media attributes")
+        }
+        val availableBytes = (fileSize - fileOffset).coerceAtLeast(0)
         bytesRemaining = if (dataSpec.length == C.LENGTH_UNSET.toLong()) {
-            fileSize - fileOffset
+            availableBytes
         } else {
-            min(fileSize, dataSpec.length)
+            min(availableBytes, dataSpec.length)
         }
         return bytesRemaining
     }
@@ -35,7 +44,10 @@ class EncryptedVolumeDataSource(private val encryptedVolume: EncryptedVolume, pr
     }
 
     override fun close() {
-        encryptedVolume.closeFile(fileHandle)
+        if (fileHandle != -1L) {
+            encryptedVolume.closeFile(fileHandle)
+            fileHandle = -1L
+        }
     }
 
     override fun addTransferListener(transferListener: TransferListener) {
@@ -43,16 +55,31 @@ class EncryptedVolumeDataSource(private val encryptedVolume: EncryptedVolume, pr
     }
 
     override fun read(buffer: ByteArray, offset: Int, readLength: Int): Int {
+        if (readLength == 0) {
+            return 0
+        }
+        val bytesToRead = min(readLength.toLong(), bytesRemaining).toInt()
+        if (bytesToRead == 0) {
+            return C.RESULT_END_OF_INPUT
+        }
         val originalOffset = fileOffset
-        while (fileOffset < originalOffset+readLength && encryptedVolume.read(
+        while (fileOffset < originalOffset + bytesToRead) {
+            val read = encryptedVolume.read(
                 fileHandle,
                 fileOffset,
                 buffer,
-                offset+(fileOffset-originalOffset),
-                (originalOffset+readLength)-fileOffset
-            ).also { fileOffset += it } > 0
-        ) {}
-        val totalRead = fileOffset-originalOffset
+                offset + (fileOffset - originalOffset),
+                (originalOffset + bytesToRead) - fileOffset
+            )
+            if (read < 0) {
+                throw IOException("Failed to read encrypted media")
+            }
+            if (read == 0) {
+                break
+            }
+            fileOffset += read
+        }
+        val totalRead = fileOffset - originalOffset
         bytesRemaining -= totalRead
         return if (totalRead == 0L) {
             C.RESULT_END_OF_INPUT

--- a/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MediaContainer.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MediaContainer.kt
@@ -1,0 +1,23 @@
+package sushi.hardcore.droidfs.file_viewers
+
+import androidx.media3.common.MimeTypes
+
+object MediaContainers {
+    private val mpegTransportStreamExtensions = setOf("mts", "m2ts")
+
+    fun mimeTypeForFileName(fileName: String): String? {
+        return if (extension(fileName) in mpegTransportStreamExtensions) {
+            MimeTypes.VIDEO_MP2T
+        } else {
+            null
+        }
+    }
+
+    fun hasPacketizedTransportStream(fileName: String): Boolean {
+        return extension(fileName) in mpegTransportStreamExtensions
+    }
+
+    private fun extension(fileName: String): String {
+        return fileName.substringAfterLast('.', "").lowercase()
+    }
+}

--- a/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MediaDataSourceFactory.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MediaDataSourceFactory.kt
@@ -1,0 +1,24 @@
+package sushi.hardcore.droidfs.file_viewers
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import sushi.hardcore.droidfs.filesystems.EncryptedVolume
+import java.io.File
+
+@OptIn(UnstableApi::class)
+class MediaDataSourceFactory(
+    encryptedVolume: EncryptedVolume,
+    filePath: String
+) : DataSource.Factory {
+    private val upstreamFactory = EncryptedVolumeDataSource.Factory(encryptedVolume, filePath)
+    private val stripPacketHeaders = MediaContainers.hasPacketizedTransportStream(File(filePath).name)
+
+    override fun createDataSource(): DataSource {
+        return if (stripPacketHeaders) {
+            MpegTsPacketHeaderStrippingDataSource(upstreamFactory)
+        } else {
+            upstreamFactory.createDataSource()
+        }
+    }
+}

--- a/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MediaPlayer.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MediaPlayer.kt
@@ -8,10 +8,12 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
-import androidx.media3.extractor.DefaultExtractorsFactory
+import com.homesoft.exo.MjpegRenderersFactory
+import com.homesoft.exo.extractor.AviExtractorsFactory
 import kotlinx.coroutines.launch
 import sushi.hardcore.droidfs.Constants
 import sushi.hardcore.droidfs.R
@@ -33,13 +35,23 @@ abstract class MediaPlayer(fullscreen: Boolean): FileViewerActivity(fullscreen) 
     protected open fun onVideoSizeChanged(width: Int, height: Int) {}
 
     private fun createMediaSource(filePath: String): MediaSource {
-        val dataSourceFactory = EncryptedVolumeDataSource.Factory(encryptedVolume, filePath)
-        return ProgressiveMediaSource.Factory(dataSourceFactory, DefaultExtractorsFactory())
-            .createMediaSource(MediaItem.fromUri(Constants.FAKE_URI))
+        val file = File(filePath)
+        val dataSourceFactory = MediaDataSourceFactory(encryptedVolume, filePath)
+        val mediaItem = MediaItem.Builder()
+            .setUri(Constants.FAKE_URI.buildUpon().appendPath(file.name).build())
+            .setMimeType(MediaContainers.mimeTypeForFileName(file.name))
+            .build()
+        return ProgressiveMediaSource.Factory(dataSourceFactory, AviExtractorsFactory())
+            .createMediaSource(mediaItem)
     }
 
     private fun initializePlayer(){
-        player = ExoPlayer.Builder(this).setSeekForwardIncrementMs(5000).build()
+        val renderersFactory = MjpegRenderersFactory(this)
+            .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER)
+            .setEnableDecoderFallback(true)
+        player = ExoPlayer.Builder(this, renderersFactory)
+            .setSeekForwardIncrementMs(5000)
+            .build()
         bindPlayer(player)
         player.addMediaSource(createMediaSource(fileViewerViewModel.filePath!!))
         lifecycleScope.launch {

--- a/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MpegTsPacketHeaderStrippingDataSource.kt
+++ b/app/src/main/java/sushi/hardcore/droidfs/file_viewers/MpegTsPacketHeaderStrippingDataSource.kt
@@ -1,0 +1,227 @@
+package sushi.hardcore.droidfs.file_viewers
+
+import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import kotlin.math.min
+
+@OptIn(UnstableApi::class)
+class MpegTsPacketHeaderStrippingDataSource(
+    private val upstreamFactory: DataSource.Factory
+) : DataSource {
+    companion object {
+        private const val TS_PACKET_SIZE = 188
+        private const val PACKETIZED_TS_PACKET_SIZE = 192
+        private const val PACKET_HEADER_SIZE = PACKETIZED_TS_PACKET_SIZE - TS_PACKET_SIZE
+        private const val TS_SYNC_BYTE = 0x47.toByte()
+        private const val PACKETS_TO_SNIFF = 3
+    }
+
+    private val transferListeners = mutableListOf<TransferListener>()
+    private val scratch = ByteArray(PACKET_HEADER_SIZE)
+
+    private var upstream: DataSource? = null
+    private var bytesRemaining = C.LENGTH_UNSET.toLong()
+    private var payloadOffset = 0
+    private var stripPacketHeaders = false
+
+    override fun open(dataSpec: DataSpec): Long {
+        close()
+
+        val layout = sniffLayout(dataSpec.uri)
+        stripPacketHeaders = layout.hasPacketHeaders
+
+        val source = upstreamFactory.createDataSource()
+        transferListeners.forEach(source::addTransferListener)
+        upstream = source
+
+        if (!stripPacketHeaders) {
+            bytesRemaining = source.open(dataSpec)
+            return bytesRemaining
+        }
+
+        val virtualLength = layout.virtualLength()
+        val availableBytes = if (virtualLength == C.LENGTH_UNSET.toLong()) {
+            C.LENGTH_UNSET.toLong()
+        } else {
+            (virtualLength - dataSpec.position).coerceAtLeast(0)
+        }
+        bytesRemaining = when {
+            dataSpec.length == C.LENGTH_UNSET.toLong() -> availableBytes
+            availableBytes == C.LENGTH_UNSET.toLong() -> dataSpec.length
+            else -> min(availableBytes, dataSpec.length)
+        }
+
+        if (bytesRemaining == 0L) {
+            return 0
+        }
+
+        payloadOffset = (dataSpec.position % TS_PACKET_SIZE).toInt()
+        source.open(dataSpec.physicalSubrange(dataSpec.position, bytesRemaining))
+        return bytesRemaining
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, readLength: Int): Int {
+        if (readLength == 0) {
+            return 0
+        }
+
+        val source = upstream ?: return C.RESULT_END_OF_INPUT
+        if (!stripPacketHeaders) {
+            return source.read(buffer, offset, readLength)
+        }
+
+        val bytesToRead = if (bytesRemaining == C.LENGTH_UNSET.toLong()) {
+            readLength
+        } else {
+            min(readLength.toLong(), bytesRemaining).toInt()
+        }
+        if (bytesToRead == 0) {
+            return C.RESULT_END_OF_INPUT
+        }
+
+        var totalRead = 0
+        while (totalRead < bytesToRead) {
+            if (payloadOffset == TS_PACKET_SIZE) {
+                if (!skipPacketHeader(source)) {
+                    break
+                }
+                payloadOffset = 0
+            }
+
+            val bytesInPacket = min(TS_PACKET_SIZE - payloadOffset, bytesToRead - totalRead)
+            val read = source.read(buffer, offset + totalRead, bytesInPacket)
+            if (read == C.RESULT_END_OF_INPUT) {
+                break
+            }
+            if (read == 0) {
+                break
+            }
+
+            totalRead += read
+            payloadOffset += read
+        }
+
+        if (totalRead == 0) {
+            return C.RESULT_END_OF_INPUT
+        }
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) {
+            bytesRemaining -= totalRead
+        }
+        return totalRead
+    }
+
+    override fun getUri(): Uri? {
+        return upstream?.uri
+    }
+
+    override fun close() {
+        upstream?.close()
+        upstream = null
+        bytesRemaining = C.LENGTH_UNSET.toLong()
+        payloadOffset = 0
+        stripPacketHeaders = false
+    }
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        transferListeners.add(transferListener)
+        upstream?.addTransferListener(transferListener)
+    }
+
+    private fun sniffLayout(uri: Uri): SourceLayout {
+        val source = upstreamFactory.createDataSource()
+        transferListeners.forEach(source::addTransferListener)
+        return try {
+            val sourceLength = source.open(DataSpec(uri, 0, C.LENGTH_UNSET.toLong()))
+            val probe = ByteArray(PACKETIZED_TS_PACKET_SIZE * PACKETS_TO_SNIFF)
+            val bytesRead = readProbe(source, probe)
+            SourceLayout(
+                physicalLength = sourceLength,
+                hasPacketHeaders = hasPacketizedTransportStreamLayout(probe, bytesRead)
+            )
+        } finally {
+            source.close()
+        }
+    }
+
+    private fun readProbe(source: DataSource, probe: ByteArray): Int {
+        var totalRead = 0
+        while (totalRead < probe.size) {
+            val read = source.read(probe, totalRead, probe.size - totalRead)
+            if (read == C.RESULT_END_OF_INPUT) {
+                break
+            }
+            if (read == 0) {
+                break
+            }
+            totalRead += read
+        }
+        return totalRead
+    }
+
+    private fun hasPacketizedTransportStreamLayout(probe: ByteArray, bytesRead: Int): Boolean {
+        if (bytesRead < PACKETIZED_TS_PACKET_SIZE * PACKETS_TO_SNIFF) {
+            return false
+        }
+
+        var packetizedSyncBytes = 0
+        var plainSyncBytes = 0
+        repeat(PACKETS_TO_SNIFF) { packetIndex ->
+            if (probe[packetIndex * PACKETIZED_TS_PACKET_SIZE + PACKET_HEADER_SIZE] == TS_SYNC_BYTE) {
+                packetizedSyncBytes++
+            }
+            if (probe[packetIndex * TS_PACKET_SIZE] == TS_SYNC_BYTE) {
+                plainSyncBytes++
+            }
+        }
+        return packetizedSyncBytes == PACKETS_TO_SNIFF && packetizedSyncBytes > plainSyncBytes
+    }
+
+    private fun skipPacketHeader(source: DataSource): Boolean {
+        var skipped = 0
+        while (skipped < PACKET_HEADER_SIZE) {
+            val read = source.read(scratch, skipped, PACKET_HEADER_SIZE - skipped)
+            if (read <= 0) {
+                return false
+            }
+            skipped += read
+        }
+        return true
+    }
+
+    private fun DataSpec.physicalSubrange(virtualPosition: Long, virtualLength: Long): DataSpec {
+        val physicalPosition = virtualToPhysicalOffset(virtualPosition)
+        val physicalLength = if (virtualLength == C.LENGTH_UNSET.toLong()) {
+            C.LENGTH_UNSET.toLong()
+        } else {
+            virtualToPhysicalOffset(virtualPosition + virtualLength - 1) + 1 - physicalPosition
+        }
+        return buildUpon()
+            .setPosition(physicalPosition)
+            .setLength(physicalLength)
+            .build()
+    }
+
+    private fun virtualToPhysicalOffset(virtualOffset: Long): Long {
+        return virtualOffset / TS_PACKET_SIZE * PACKETIZED_TS_PACKET_SIZE +
+                PACKET_HEADER_SIZE +
+                virtualOffset % TS_PACKET_SIZE
+    }
+
+    private data class SourceLayout(
+        val physicalLength: Long,
+        val hasPacketHeaders: Boolean
+    ) {
+        fun virtualLength(): Long {
+            return if (physicalLength == C.LENGTH_UNSET.toLong()) {
+                C.LENGTH_UNSET.toLong()
+            } else {
+                physicalLength / PACKETIZED_TS_PACKET_SIZE * TS_PACKET_SIZE
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,18 @@
 plugins {
-    id("com.android.application") version '8.9.2' apply false
-    id("org.jetbrains.kotlin.android") version "2.1.20" apply false
+    id("com.android.application") version '8.13.2' apply false
+    id("org.jetbrains.kotlin.android") version "2.3.10" apply false
 }
 
 allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url 'https://jitpack.io'
+            content {
+                includeGroup 'com.github.dburckh'
+            }
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 #Thu May 01 15:31:31 UTC 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionSha256Sum=20f1b1176237254a6fc204d8434196fa11a4cfb387567519c61556e8710aed78
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,6 @@ pluginManagement {
     }
 }
 include ':app', ':libpdfviewer:app'
+// The submodule's root build file is only for standalone builds and pins its own plugin versions.
+project(':libpdfviewer').buildFileName = 'droidfs-empty.gradle'
 rootProject.name = "DroidFS"


### PR DESCRIPTION
As discussed, here is support for a few more video formats, without wholesale switching to LibVLC.

.mts, .m2ts, and .avi are supported. .ts could also be supported, if the file type was changed from text to video.

.avi support is not universal - it depends on the codec: MJPEG and H264 will probably work well, but more niche codecs like Indeo or HuffYuv probably won't.

Media3 is pinned to 1.7.1 because Media3Avi 2.7.1 targets that release. The Jellyfin FFmpeg artifact is named 1.6.1+2, but its published POM also targets Media3 1.7.1.

The build toolchain is updated together to compatible versions: Gradle 8.13, Android Gradle Plugin 8.13.2, and Kotlin 2.3.10.